### PR TITLE
Fix TIE/SA Bomber expansion counts

### DIFF
--- a/src/expansions/expansions.json
+++ b/src/expansions/expansions.json
@@ -11761,27 +11761,27 @@
         "xws": "tiesabomber"
       },
       {
-        "count": 0,
+        "count": 1,
         "type": "pilot",
         "xws": "deathfire"
       },
       {
-        "count": 0,
+        "count": 1,
         "type": "pilot",
         "xws": "captainjonus"
       },
       {
-        "count": 0,
+        "count": 1,
         "type": "pilot",
         "xws": "tomaxbren"
       },
       {
-        "count": 0,
+        "count": 2,
         "type": "pilot",
         "xws": "majorrhymer"
       },
       {
-        "count": 1,
+        "count": 2,
         "type": "pilot",
         "xws": "scimitarsquadronpilot"
       },
@@ -11791,32 +11791,32 @@
         "xws": "gammasquadronace"
       },
       {
-        "count": 0,
+        "count": 1,
         "type": "pilot",
         "xws": "deathfire-swz98"
       },
       {
-        "count": 0,
+        "count": 1,
         "type": "pilot",
         "xws": "captainjonus-swz98"
       },
       {
-        "count": 0,
+        "count": 1,
         "type": "pilot",
         "xws": "tomaxbren-swz98"
       },
       {
-        "count": 0,
+        "count": 1,
         "type": "pilot",
         "xws": "majorrhymer-swz98"
       },
       {
-        "count": 1,
+        "count": 2,
         "type": "upgrade",
         "xws": "advprotontorpedoes"
       },
       {
-        "count": 1,
+        "count": 2,
         "type": "upgrade",
         "xws": "protonbombs"
       },
@@ -11826,42 +11826,42 @@
         "xws": "connernets"
       },
       {
-        "count": 0,
+        "count": 1,
         "type": "upgrade",
         "xws": "seismiccharges"
       },
       {
-        "count": 0,
+        "count": 1,
         "type": "upgrade",
         "xws": "clustermissiles"
       },
       {
-        "count": 0,
+        "count": 1,
         "type": "upgrade",
         "xws": "saturationsalvo"
       },
       {
-        "count": 0,
+        "count": 1,
         "type": "upgrade",
         "xws": "ionmissiles"
       },
       {
-        "count": 0,
+        "count": 1,
         "type": "upgrade",
         "xws": "skilledbombardier"
       },
       {
-        "count": 1,
+        "count": 2,
         "type": "upgrade",
         "xws": "ionbombs"
       },
       {
-        "count": 1,
+        "count": 2,
         "type": "upgrade",
         "xws": "feedbackping"
       },
       {
-        "count": 1,
+        "count": 2,
         "type": "upgrade",
         "xws": "disciplined"
       }


### PR DESCRIPTION
This had pre-release 0's in it for the TIE/SA Bomber Expansion.

Note that the name is still "TIE/sa TIE Bomber" to match YASB but the 2nd TIE is redundant and not really in the name.