### PR TITLE
Bump xwing-data2 and remove clippy from cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,3 @@ rust_xlsxwriter = "0.48.0"
 serde = { version = "1.0.174", features = ["derive", "serde_derive"] }
 serde_json = "1.0.103"
 strum = { version = "0.25.0", features = ["derive"] }
-
-[dev-dependencies]
-clippy = "0.0.302"


### PR DESCRIPTION
Quick update to bump the xwing-data2 submodule.