### PR TITLE
Add missing unreleased ships

### DIFF
--- a/src/expansions/expansions.json
+++ b/src/expansions/expansions.json
@@ -12442,6 +12442,31 @@
         "count": 1,
         "type": "ship",
         "xws": "upsilonclassshuttle"
+      },
+      {
+        "count": 1,
+        "type": "ship",
+        "xws": "tiecapunisher"
+      },
+      {
+        "count": 1,
+        "type": "ship",
+        "xws": "tiephphantom"
+      },
+      {
+        "count": 1,
+        "type": "ship",
+        "xws": "aggressorassaultfighter"
+      },
+      {
+        "count": 1,
+        "type": "ship",
+        "xws": "raiderclasscorvette"
+      },
+      {
+        "count": 1,
+        "type": "ship",
+        "xws": "gr75mediumtransport"
       }
     ],
     "name": "Unreleased for 2nd Edition",

--- a/src/expansions/mod.rs
+++ b/src/expansions/mod.rs
@@ -214,4 +214,25 @@ mod test {
             }
         }
     }
+
+    #[test]
+    fn test_for_missing_ships() {
+        // checks if all the contents are valid xwsdata
+        let cat = Catalog::load().unwrap();
+
+        let data = Data::load_from_manifest(Path::new("xwing-data2")).unwrap();
+
+        for s in &data.ships {
+            let mut found = false;
+            'search: for (_, e) in &cat.expansions {
+                for i in &e.contents {
+                    if i.item.r#type == ItemType::Ship && i.item.xws == s.xws {
+                        found = true;
+                        break 'search;
+                    }
+                }
+            }
+            assert!(found, "ship not found in expansions: {}", s.xws);
+        }
+    }
 }


### PR DESCRIPTION
Added a few missing ships to the "unreleased" expansion.

It might be better use xwing-data2 as the source of truth for all components, and use expansions as necessary, but this was the simplest thing that could work.