### PR TITLE
Remove double-count delta7

### DIFF
--- a/src/expansions/expansions.json
+++ b/src/expansions/expansions.json
@@ -5296,11 +5296,6 @@
         "xws": "delta7aethersprite"
       },
       {
-        "count": 1,
-        "type": "ship",
-        "xws": "delta7baethersprite"
-      },
-      {
         "count": 2,
         "type": "ship",
         "xws": "v19torrentstarfighter"
@@ -5683,11 +5678,6 @@
         "count": 1,
         "type": "ship",
         "xws": "delta7aethersprite"
-      },
-      {
-        "count": 1,
-        "type": "ship",
-        "xws": "delta7baethersprite"
       },
       {
         "count": 1,
@@ -11133,7 +11123,7 @@
       {
         "count": 1,
         "type": "upgrade",
-        "xws": "sabinewren-swz93"
+        "xws": "sabinewren-command"
       },
       {
         "count": 1,

--- a/src/yasb2/mod.rs
+++ b/src/yasb2/mod.rs
@@ -66,6 +66,8 @@ pub fn to_canonical(name: &str) -> String {
         .collect::<String>()
 }
 
+const YASB_FIRST_ED: &str = "-yasb-first-edition";
+
 /// This function implements special cases where the yasb name does not match
 /// the generated xws name or performs standard xws mapping for everything else.
 ///
@@ -78,7 +80,7 @@ fn to_xws(name: &str, typ: expansions::ItemType) -> String {
     // the correct one, which does correctly cannonicalize to xws.
     match name {
         "TIE/FO Fighter" | "E-Wing" | "T-70 X-Wing" | "TIE/SF Fighter" => {
-            canonical.push_str("-legacyyasb");
+            canonical.push_str(YASB_FIRST_ED);
             return canonical;
         }
         _ => (),
@@ -158,7 +160,7 @@ fn to_xws(name: &str, typ: expansions::ItemType) -> String {
             | "yt2400"
             | "ywing"
             | "z95headhunter" => {
-                canonical.push_str("-legacyyasb");
+                canonical.push_str(YASB_FIRST_ED);
                 canonical.as_str()
             }
             _ => canonical.as_str(),


### PR DESCRIPTION
Double counting was more wrong than not showing Delta 7B in a collection, because it is technically a configuration, not a separate ship.